### PR TITLE
perf(flight-tune): price the journal catalog audit per action, not per sample (#581)

### DIFF
--- a/tools/flight-tune-campaign/src/bench/qualifying/trial.rs
+++ b/tools/flight-tune-campaign/src/bench/qualifying/trial.rs
@@ -15,12 +15,11 @@ pub(super) const BENCH_MAX_SAMPLES: u32 = 700;
 /// How long one sample of the bench may take to arrive.
 ///
 /// The mission wall ceiling is this timeout for every permitted sample, so the
-/// value prices the slowest sample a campaign can produce. The engine verifies
-/// the complete durable journal once for each sample, and a campaign that
-/// searches several suites writes more journal entries than one that searches
-/// a single set, so the last runs of the longest campaign state the slowest
-/// samples the bench has to allow.
-const BENCH_RECEIPT_TIMEOUT_NS: u64 = 400_000_000;
+/// value prices the slowest sample a campaign can produce. A sample proves the
+/// journal authority it acts under, and that proof costs the same at every
+/// journal length, so the value prices the plant and the evaluators rather
+/// than the journal a long campaign reaches.
+const BENCH_RECEIPT_TIMEOUT_NS: u64 = 200_000_000;
 
 const BENCH_COMPLETION_TIME_NS: u64 = 10_480_000_000;
 

--- a/tools/flight-tune/src/campaign/evaluate/stream.rs
+++ b/tools/flight-tune/src/campaign/evaluate/stream.rs
@@ -60,8 +60,12 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
+    // No entry is appended while a run streams, so the checks inside this loop
+    // prove authority alone. The complete catalog audit costs the journal
+    // length and holds at the run's admission and terminal instead, which keeps
+    // a long journal from pricing every sample of every later run.
     loop {
-        if let Err(error) = journal.ensure_usable() {
+        if let Err(error) = journal.ensure_authority() {
             return StreamOutcome::failed(error);
         }
         match backend.sample_blocking(timeout) {
@@ -206,7 +210,7 @@ fn advance_mission<B: CampaignBackend>(
             wall_time_ns,
             &mut || {
                 journal
-                    .ensure_usable()
+                    .ensure_authority()
                     .map_err(|source| crate::ScenarioRuntimeError::Authority { source })
             },
         )
@@ -366,14 +370,14 @@ where
     G: GateEvaluator,
     M: MetricEvaluator,
 {
-    journal.ensure_usable()?;
+    journal.ensure_authority()?;
     let outcomes = gates
         .evaluate(sample)
         .map_err(|source| evaluator_error(gates.identity(), "evaluate hard gates", source))?;
     if let Some(failure) = validate_gate_outcomes(&stage.required_hard_gates, &outcomes)? {
         return Ok(Some(failure));
     }
-    journal.ensure_usable()?;
+    journal.ensure_authority()?;
     metric
         .observe(sample)
         .map_err(|source| evaluator_error(metric.identity(), "observe metric", source))?;

--- a/tools/flight-tune/src/campaign/tests/journal_poison/catalog.rs
+++ b/tools/flight-tune/src/campaign/tests/journal_poison/catalog.rs
@@ -37,6 +37,54 @@ fn an_ancestor_entry_change_poison_stops_the_next_action() {
     assert_snapshot(&tuner, &directory, &state, &proposals, &expected);
 }
 
+/// States the interval the catalog audit holds at.
+///
+/// The audit runs at each action boundary, not at each telemetry sample, so a
+/// change made while a sample is in flight does not stop that sample. One
+/// sample drives two authorized actions, the observation and the directive it
+/// emits, and both take place. The run then refuses to finish and the journal
+/// is poisoned, so the changed bytes reach no result and no later action.
+///
+/// The error variant says which check refused. A sample-time refusal reaches
+/// the caller as `TuneError::Adapter`, because the authority hook reports
+/// through the scenario runtime; the terminal audit reports the storage
+/// failure itself. The contrast is
+/// `tests/tuner/scenario_authority.rs::authority_change_during_sampling_precedes_vehicle_action`,
+/// where a moved head does stop the sample, because authority is checked at
+/// every sample and costs the same at every journal length.
+#[test]
+fn an_ancestor_entry_change_while_sampling_stops_the_run_at_its_terminal() {
+    let directory = TestDirectory::new("sampled-ancestor-entry");
+    let state = FakeHandle::new();
+    let (mut tuner, proposals) = open_tuner(&directory, state.clone(), Vec::new());
+    let started = serde_json::to_vec(&tuner.journal().entries()[0]).expect("encode started entry");
+    let digest = crate::identity::digest_bytes(&started);
+    state.0.borrow_mut().change_object_on_sample = Some(
+        directory
+            .path()
+            .join("entries")
+            .join(format!("{digest}.json")),
+    );
+
+    let error = tuner
+        .run_training_attempts_blocking(0)
+        .expect_err("reject changed ancestor");
+
+    let acted = {
+        let state = state.0.borrow();
+        (
+            state.scenario_action_observe_count,
+            state.scenario_action_stop_count,
+            state.scenario_action_cleanup_count,
+        )
+    };
+    assert_eq!(acted, (2, 1, 1));
+    assert_digest_mismatch(error);
+    let poisoned = EvidenceSnapshot::new(&tuner, &directory, &state, &proposals);
+    assert_poisoned(tuner.freeze_candidate());
+    assert_snapshot(&tuner, &directory, &state, &proposals, &poisoned);
+}
+
 #[test]
 fn a_missing_stage_poison_stops_the_next_action() {
     let directory = TestDirectory::new("missing-stage");

--- a/tools/flight-tune/src/journal.rs
+++ b/tools/flight-tune/src/journal.rs
@@ -1,6 +1,7 @@
 //! Content-addressed tuning journal and campaign state.
 
 mod attempt;
+mod authority;
 mod closure;
 mod event;
 mod evidence;
@@ -26,7 +27,7 @@ pub use evidence::{
 pub use proof::{AUTHENTICATED_EVALUATION_PROOF_SCHEMA_VERSION, AuthenticatedEvaluationProof};
 pub use retry::quarantine_reason_digest;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 
 use serde::{Deserialize, Serialize};
 
@@ -210,69 +211,12 @@ impl Journal {
 
     pub(crate) fn read_candidate(&self, digest: Digest) -> Result<Candidate, TuneError> {
         self.ensure_usable()?;
-        storage::read_candidate(&self.storage, digest).inspect_err(|_| {
-            self.poisoned.store(true, Ordering::Release);
-        })
+        storage::read_candidate(&self.storage, digest).inspect_err(|_| self.poison())
     }
 
     /// Returns the frozen stage this journal was opened against.
     pub(crate) const fn stage(&self) -> &SearchStage {
         &self.stage
-    }
-
-    pub(crate) fn ensure_usable(&self) -> Result<(), TuneError> {
-        if self.poisoned.load(Ordering::Acquire) {
-            return Err(TuneError::JournalPoisoned);
-        }
-        storage::verify_live_snapshot(
-            &self.storage,
-            &self.writer,
-            &self.stage,
-            &self.entries,
-            &self.entry_digests,
-        )
-        .inspect_err(|_| {
-            self.poisoned.store(true, Ordering::Release);
-        })
-    }
-
-    pub(crate) fn poison(&self) {
-        self.poisoned.store(true, Ordering::Release);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn ensure_usable_with_final_hook_for_test(
-        &self,
-        before_final_writer_validation: impl FnOnce(),
-    ) -> Result<(), TuneError> {
-        if self.poisoned.load(Ordering::Acquire) {
-            return Err(TuneError::JournalPoisoned);
-        }
-        storage::verify_live_snapshot_with_final_hook_for_test(
-            &self.storage,
-            &self.writer,
-            &self.stage,
-            &self.entries,
-            &self.entry_digests,
-            before_final_writer_validation,
-        )
-        .inspect_err(|_| {
-            self.poisoned.store(true, Ordering::Release);
-        })
-    }
-
-    fn record_storage_result<T>(&self, result: Result<T, TuneError>) -> Result<T, TuneError> {
-        result.inspect_err(|error| {
-            if error.poisons_journal() {
-                self.poisoned.store(true, Ordering::Release);
-            }
-        })
-    }
-
-    fn record_append_result<T>(&self, result: Result<T, TuneError>) -> Result<T, TuneError> {
-        result.inspect_err(|_| {
-            self.poisoned.store(true, Ordering::Release);
-        })
     }
 
     pub(crate) fn state(&self) -> &JournalState {

--- a/tools/flight-tune/src/journal/authority.rs
+++ b/tools/flight-tune/src/journal/authority.rs
@@ -1,0 +1,105 @@
+//! The two live checks a journal holder makes before it acts.
+//!
+//! A holder proves two different things about the same journal.
+//!
+//! *Authority* is the right to act at all: this process still holds the writer
+//! lease over an authorized layout, and the durable head is still the exact
+//! entry this holder believes it wrote. Its cost is the same at every journal
+//! length.
+//!
+//! *The catalog audit* is the stronger claim that every durable byte this
+//! holder has ever verified is still that byte: the complete entry chain, the
+//! stored search stage, and every candidate the chain names. Its cost grows
+//! with the journal, so the interval it holds at is a deliberate choice rather
+//! than a consequence of where the check is convenient to call.
+//!
+//! `Journal::ensure_usable` makes both claims and states that interval: it
+//! runs at every campaign action boundary and inside every durable append, so
+//! an in-place change to an object this holder already verified refuses the
+//! next action and can never enter the chain. `Journal::ensure_authority`
+//! makes only the first claim, for the sample stream, where no entry is
+//! appended and the audit would otherwise repeat once for every telemetry
+//! sample.
+
+use std::sync::atomic::Ordering;
+
+use super::{Journal, storage};
+use crate::TuneError;
+
+impl Journal {
+    /// Verifies the live authority and audits the complete durable catalog.
+    ///
+    /// This is the check every campaign action boundary makes. It refuses an
+    /// in-place change to any durable object the journal names, including one
+    /// no live operation reads.
+    pub(crate) fn ensure_usable(&self) -> Result<(), TuneError> {
+        self.guard(|| {
+            storage::verify_live_snapshot(
+                &self.storage,
+                &self.writer,
+                &self.stage,
+                &self.entries,
+                &self.entry_digests,
+            )
+        })
+    }
+
+    /// Verifies the live authority alone, without the catalog audit.
+    ///
+    /// The sample stream calls this before each external action on the
+    /// vehicle. It refuses a moved head, a changed layout, and a lost writer
+    /// lease, which are the conditions that take away the right to act. It
+    /// does not read the chain, so a change to an already-verified object is
+    /// refused at the run terminal instead of at the sample that follows it.
+    pub(crate) fn ensure_authority(&self) -> Result<(), TuneError> {
+        self.guard(|| {
+            storage::verify_live_authority(&self.storage, &self.writer, &self.entry_digests)
+        })
+    }
+
+    pub(crate) fn poison(&self) {
+        self.poisoned.store(true, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ensure_usable_with_final_hook_for_test(
+        &self,
+        before_final_writer_validation: impl FnOnce(),
+    ) -> Result<(), TuneError> {
+        self.guard(|| {
+            storage::verify_live_snapshot_with_final_hook_for_test(
+                &self.storage,
+                &self.writer,
+                &self.stage,
+                &self.entries,
+                &self.entry_digests,
+                before_final_writer_validation,
+            )
+        })
+    }
+
+    pub(super) fn record_storage_result<T>(
+        &self,
+        result: Result<T, TuneError>,
+    ) -> Result<T, TuneError> {
+        result.inspect_err(|error| {
+            if error.poisons_journal() {
+                self.poison();
+            }
+        })
+    }
+
+    pub(super) fn record_append_result<T>(
+        &self,
+        result: Result<T, TuneError>,
+    ) -> Result<T, TuneError> {
+        result.inspect_err(|_| self.poison())
+    }
+
+    fn guard(&self, verify: impl FnOnce() -> Result<(), TuneError>) -> Result<(), TuneError> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(TuneError::JournalPoisoned);
+        }
+        verify().inspect_err(|_| self.poison())
+    }
+}

--- a/tools/flight-tune/src/journal/storage.rs
+++ b/tools/flight-tune/src/journal/storage.rs
@@ -126,13 +126,15 @@ pub(super) fn verify_live_snapshot_with_final_hook_for_test(
     )
 }
 
-fn verify_live_snapshot_with_hook(
+/// Verifies that this process still holds authority over the exact live head.
+///
+/// The check reads the layout marker, the four directory handles, the writer
+/// lease, and the head pointer. It reads no chain entry, no search stage, and
+/// no candidate, so its cost is the same at every journal length.
+pub(super) fn verify_live_authority(
     storage: &JournalStorage,
     writer: &WriterLock,
-    stage: &SearchStage,
-    entries: &[JournalEntry],
     entry_digests: &[Digest],
-    before_final_writer_validation: impl FnOnce(),
 ) -> Result<(), TuneError> {
     layout::verify_authorized(&storage.root)?;
     layout::verify_handles(
@@ -142,14 +144,28 @@ fn verify_live_snapshot_with_hook(
         &storage.entries,
     )?;
     writer.validate(&storage.root).map_err(storage_error)?;
-    let expected_head = entry_digests
+    verify_head_exact(storage, live_head(entry_digests)?)
+}
+
+fn live_head(entry_digests: &[Digest]) -> Result<Digest, TuneError> {
+    entry_digests
         .last()
         .copied()
-        .ok_or_else(|| invalid_journal("the live journal has no head"))?;
-    verify_head_exact(storage, expected_head)?;
+        .ok_or_else(|| invalid_journal("the live journal has no head"))
+}
+
+fn verify_live_snapshot_with_hook(
+    storage: &JournalStorage,
+    writer: &WriterLock,
+    stage: &SearchStage,
+    entries: &[JournalEntry],
+    entry_digests: &[Digest],
+    before_final_writer_validation: impl FnOnce(),
+) -> Result<(), TuneError> {
+    verify_live_authority(storage, writer, entry_digests)?;
     verify_entry_chain(storage, entries, entry_digests)?;
     verify_stage_and_candidates(storage, stage, entries)?;
-    verify_head_exact(storage, expected_head)?;
+    verify_head_exact(storage, live_head(entry_digests)?)?;
     layout::verify_authorized(&storage.root)?;
     layout::verify_handles(
         &storage.marker,

--- a/tools/flight-tune/tests/tuner/test_rig.rs
+++ b/tools/flight-tune/tests/tuner/test_rig.rs
@@ -210,6 +210,8 @@ pub struct FakeState {
     pub change_head_on_prepare: Option<PathBuf>,
     pub change_head_on_action_prepare: Option<PathBuf>,
     pub change_head_on_sample: Option<PathBuf>,
+    /// The durable journal object whose bytes change while a sample is made.
+    pub change_object_on_sample: Option<PathBuf>,
     pub bad_scenario_readback: bool,
     pub bad_mission_content: bool,
     pub bad_mission_revision: bool,

--- a/tools/flight-tune/tests/tuner/test_rig/backend.rs
+++ b/tools/flight-tune/tests/tuner/test_rig/backend.rs
@@ -228,9 +228,13 @@ impl CampaignBackend for FakeBackend {
         state.lifecycle.push("sample".to_owned());
         let values = BTreeMap::from([("gain".to_owned(), state.vehicle.gain)]);
         let head_change = state.change_head_on_sample.take();
+        let object_change = state.change_object_on_sample.take();
         drop(state);
         if let Some(root) = head_change {
             change_head_digest(&root);
+        }
+        if let Some(object) = object_change {
+            change_object_bytes(&object);
         }
         Ok(SampleEvent::Sample(TelemetrySample {
             sequence,
@@ -394,4 +398,10 @@ fn change_head_digest(root: &Path) {
         b'0'
     };
     std::fs::write(head, bytes).expect("change journal head");
+}
+
+fn change_object_bytes(path: &Path) {
+    let mut bytes = std::fs::read(path).expect("read journal object");
+    bytes.push(b' ');
+    std::fs::write(path, bytes).expect("change journal object");
 }


### PR DESCRIPTION
A journal holder now proves two different things. *Authority* — the writer
lease over an authorized layout, and the exact durable head — is proven before
every external action, including every telemetry sample, and costs the same at
every journal length. *The catalog audit* — every durable byte this holder has
verified is still that byte — holds at every campaign action boundary and
inside every durable append. The sample stream no longer repeats the audit once
per sample. SIM / NOT FOR FLIGHT.

## The question the issue asks first: contract or accident

**Contract.** Mid-run detection of an in-place change to already-verified bytes
is deliberate and directly tested. Two tests in
`tools/flight-tune/src/campaign/tests/journal_poison/catalog.rs` exist for no
other purpose, and each selects an object that no live operation reads:

- `an_ancestor_entry_change_poison_stops_the_next_action` (`catalog.rs:13`)
  changes entry 0 — the `Started` entry — after a completed baseline, and
  requires the next action to fail with `StorageError::ContentMismatch`.
  `verify_entry_chain` is the only code that reads those bytes.
- `a_changed_noncurrent_candidate_poison_stops_the_next_action`
  (`catalog.rs:66`) selects a prepared candidate with
  `*digest != current && *digest != initial` and requires the same failure. The
  full dedup scan in `verify_stage_and_candidates` is the only code that reads
  it.

The names say `ancestor` and `noncurrent`. Commit `7b847bdb` introduces
`verify_live_snapshot` in `journal/storage.rs` and adds
`journal_poison/catalog.rs` in the same change, so the scan and its probes were
written together.
`candidate_audit_reads_each_digest_once_in_entry_order`
(`journal/storage/tests/prospective.rs:267`) pins the dedup set semantics of
`candidate_digests_to_verify` on its own.

This branch therefore does **not** incrementalize the audit. It keeps the audit
whole and states the interval it holds at.

## The interval, stated

- **Every campaign action boundary.** Every public `Tuner` entry point and
  every internal step that reaches the vehicle, the evaluators, or the durable
  store still calls `Journal::ensure_usable`, whose behavior is unchanged.
- **Every durable append.** `journal/storage/append.rs` runs
  `verify_prospective_snapshot` three times around each compare-exchange and is
  untouched, so changed bytes can never enter the chain whatever the sample
  stream saw.
- **Every scenario run's admission and terminal.** `admit_campaign_mission`,
  `start_campaign_action_port` and `finish_normal_run_blocking` bracket each run
  with the audit.
- **Not each telemetry sample.** The four per-sample call sites in
  `campaign/evaluate/stream.rs` now call `Journal::ensure_authority`. One sample
  reaches two of them, because `advance_authorized_blocking` authorizes the
  observation and the directive it emits separately.

**Residual, stated plainly.** Each sample drives external action on the
vehicle. Between a run's admission and its terminal, an in-place change to an
already-verified entry, stage, or candidate no longer stops the sample that
follows it: the vehicle acts on that sample. The run then refuses to finish and
the journal is poisoned, so the changed bytes reach no result, no evidence, and
no later action. A moved head, a changed layout, and a lost writer lease — the
conditions that take away the right to act at all — still stop the sample
itself.

## Test-by-test classification

Under this design no existing test's code path changes: `ensure_usable` and
`append.rs` keep the same behavior, byte for byte, so the whole suite passing is
the proof. The four files whose verdict depended on the design were re-read
directly — `journal_poison/catalog.rs`, `journal_poison/writer_lease.rs`,
`journal_poison/prospective_authorization.rs`, and
`tests/tuner/scenario_authority.rs`.

| Detection point | Files | Effect |
| --- | --- | --- |
| At open or resume | `journal/storage/tests.rs`, `tests/tuner/journal_storage.rs`, `journal_poison/schema.rs`, `tests/tuner/promotion_chain_tamper.rs`, `tests/tuner/transition_chain_tamper.rs`, and the head-rewind recovery tests in `promotion_recovery.rs`, `recovery_order.rs`, `transition_authorization.rs`, `terminal.rs` | Unchanged. `resume` replays, audits recorded bindings, then calls `ensure_usable`. |
| At append, inside the compare-exchange guard | `journal/storage/tests/prospective.rs`, `journal_poison/prospective_authorization.rs`, `journal_poison/durable_publication.rs`, `journal_poison/promotion_closure_fault.rs`, `journal_poison.rs` | Unchanged. `append.rs` still full-audits three times per append. |
| Mid-run, on already-verified bytes, at an action boundary | `journal_poison/catalog.rs` | Unchanged. All four tamper between actions, and the next action still audits the whole catalog. |
| Mid-run, on live authority | `journal_poison/authorization.rs`, `journal_poison/writer_lease.rs`, `journal_poison/external_action.rs`, `tests/tuner/terminal/journal_authority.rs`, `tests/tuner/scenario_authority.rs` | Unchanged. Head, layout, handles and lease stay on the per-sample path. `a_writer_lock_change_after_the_final_catalog_scan_fails_that_audit` still pins the trailing `writer.validate`, which the refactor keeps verbatim. |
| In-memory replay | `journal/replay/terminal/tamper_tests.rs`, `promotion_evidence_tamper.rs`, `terminal/evidence.rs` | Unaffected; they touch no storage. |

No existing test needed a changed assertion, and none now passes for a
different reason.

## The guardrail

`catalog.rs::an_ancestor_entry_change_while_sampling_stops_the_run_at_its_terminal`
changes entry 0 while a sample is in flight, through a new
`change_object_on_sample` hook on the fake backend, and asserts all three parts
of the statement at once:

- the vehicle acted on that sample — `(observe, stop, cleanup) == (2, 1, 1)`,
- the run still failed with `StorageError::ContentMismatch`, and
- the journal is poisoned, with no further drift in the evidence snapshot.

On `main` the first assertion reads `(0, 1, 1)`: the per-sample audit stops the
sample before the vehicle acts. The count assertion comes first for that
reason, so the fail-before message states the interval rather than an error
variant. The variant is load-bearing too: a sample-time refusal reaches the
caller as `TuneError::Adapter`, because the authority hook reports through the
scenario runtime, while the terminal audit reports the storage failure itself.

The test sits beside `an_ancestor_entry_change_poison_stops_the_next_action`,
which states the action-boundary half of the same contract, and contrasts with
`tests/tuner/scenario_authority.rs::authority_change_during_sampling_precedes_vehicle_action`,
where a moved head does stop the sample.

## Design

`journal/storage.rs` extracts `verify_live_authority`: the layout marker, the
four directory handles, the writer lease, and the head pointer, in exactly the
order `verify_live_snapshot` already checked them. `verify_live_snapshot` calls
it and then adds the chain walk, the stage, the candidate scan, and the
trailing head, layout, handles and lease checks, unchanged.

`journal/authority.rs` is a new module holding the `impl Journal` block for both
checks, the poison flag, and the two result recorders; its module doc states the
interval. `journal.rs` drops from 470 to 414 lines.

The per-sample hook already said what it was for: the mission engine reports its
failure as `ScenarioRuntimeError::Authority`. It now checks exactly authority.

## A/B

Method follows PR #582: same machine, one measurement at a time. Other agents
were running their own campaigns during the baseline, so CPU time is reported
beside wall time as the load-independent number. The two ratios agree, which is
the check that contention did not produce the result.

| Measure | `main` (`a2a1868f`) | this branch | ratio |
| --- | --- | --- | --- |
| `-p flight-tune-campaign -- --ignored --test-threads 2` | 2518 s wall, 4753 s CPU | 142 s wall, 280 s CPU | 17.7x wall, 17.0x CPU |
| `a_campaign_smokes_the_whole_chain` | 781 s wall, 761 s CPU | 53 s wall, 51 s CPU | 14.8x wall, 14.9x CPU |

Both vehicles still seal `Qualified`: the certification is 3 passed, and
`a_campaign_runs_end_to_end_for_the_alia250` and
`a_campaign_runs_end_to_end_for_the_x500` each assert the outcome rather than
merely a verdict. Repeated after the rebase onto #589: 142.4 s, 3 passed.

## The bench budget knob

`BENCH_RECEIPT_TIMEOUT_NS` returns from 400 ms to 200 ms, which restores the
140 s mission wall ceiling that #582 had to raise to price this curve.

The value is honest to move because it is a ceiling and not a pace:
`BenchBackend::sample_blocking` takes its timeout as `_timeout` and ignores it,
so a lower value cannot slow a run down, only refuse one that overruns. The
certification passes with the ceiling restored, so the runs now fit inside the
budget that the per-sample audit had pushed 0.06 percent over.

## Boundary

No change to the chain format, the entry schema, or any evidence semantics.
`JOURNAL_SCHEMA_VERSION` and every evidence schema version are unchanged.

## Gates

Run at the final commit, workspace clippy last, after rebasing onto #589.

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo test --workspace --all-targets` | pass |
| `RUSTDOCFLAGS="-D missing_docs -D rustdoc::broken_intra_doc_links" cargo doc --no-deps` | pass |
| `cargo build --release` | pass |
| `scripts/check-structure.sh` | pass |
| `scripts/check-flight-tune-contracts.py` | pass |
| `scripts/check-flight-tune-boundaries.sh` | pass |
| `scripts/check-feedback-verifier-boundary.py` | pass |
| `scripts/check-monotonic-counter-arithmetic.sh` | pass |
| `cargo run -p xtask -- guards` | 20 pairs ok |
| `cargo test -p flight-tune-campaign -- --ignored --test-threads 2` | 3 passed, 142.4 s |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass (last) |

Fixes #581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S
