### PR TITLE
Observe supervisor events instead of matching its budget (#585)

### DIFF
--- a/tools/flight-tune-aviate/tests/process_supervision/driver.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/driver.rs
@@ -70,16 +70,7 @@ impl DriverProcess {
     }
 
     pub(crate) fn read_attestation(&mut self) -> SupervisionAttestation {
-        let timeout = super::EVENT_TIMEOUT
-            .saturating_mul(5)
-            .saturating_add(std::time::Duration::from_secs(5));
-        let bytes = match self.attestation.recv_timeout(timeout) {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                self.stop_after_report_failure();
-                panic!("driver report channel failed: {error}");
-            }
-        };
+        let bytes = self.recv_report_or_exit();
         self.ready_reader
             .take()
             .expect("driver evidence reader is present")
@@ -88,6 +79,38 @@ impl DriverProcess {
         match serde_json::from_slice(&bytes).expect("decode driver supervision report") {
             DriverReport::Ready(attestation) => *attestation,
             DriverReport::Failed { detail } => self.reap_reported_failure(&detail),
+        }
+    }
+
+    // Polls the report channel in short slices instead of one long wait,
+    // so a driver that exits before it reports is caught by its process
+    // exit rather than by the wall-clock ceiling below. A driver that
+    // never opens the ready FIFO leaves its reader thread blocked in
+    // `File::open` forever, so the channel itself never disconnects on
+    // its own; watching the child directly is the only way to surface
+    // that failure before the ceiling expires.
+    fn recv_report_or_exit(&mut self) -> Vec<u8> {
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+        let ceiling = super::EVENT_TIMEOUT
+            .saturating_mul(5)
+            .saturating_add(std::time::Duration::from_secs(5));
+        let deadline = std::time::Instant::now() + ceiling;
+        loop {
+            match self.attestation.recv_timeout(POLL_INTERVAL) {
+                Ok(bytes) => return bytes,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    self.stop_after_report_failure();
+                    panic!("driver report channel closed without a report");
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
+            if let Some(status) = self.child.try_wait().expect("inspect supervision driver") {
+                panic!("supervision driver exited before reporting readiness: {status}");
+            }
+            if std::time::Instant::now() >= deadline {
+                self.stop_after_report_failure();
+                panic!("driver report channel failed: timed out waiting on channel");
+            }
         }
     }
 

--- a/tools/flight-tune-aviate/tests/process_supervision/support.rs
+++ b/tools/flight-tune-aviate/tests/process_supervision/support.rs
@@ -22,13 +22,30 @@ pub(super) use evidence_fixtures::{
     add_unlinked_temporary, digest_bytes, replace_file_bytes,
 };
 
-// A deadline, not a pace: healthy fixtures finish in well under a
-// second, and only a genuinely hung run waits this long. The suite
-// spawns supervisor and target processes from parallel test threads,
-// and on a loaded two-core CI runner a fixture's owner readiness can
-// take tens of seconds of wall time — a tight deadline there reads as
-// a supervision defect when it is only scheduling.
-const EVENT_TIMEOUT: Duration = Duration::from_secs(60);
+// The supervisor's own startup and cleanup work is bounded by this
+// duration (`make_request` hands it to production as `startup_timeout`
+// and `cleanup_timeout`). Healthy fixtures finish in well under a
+// second; only a genuinely hung run consumes the full budget.
+const SUPERVISOR_TIMEOUT: Duration = Duration::from_secs(60);
+
+// A FIFO open, a FIFO EOF, or a channel message is the external sign
+// that a supervisor-bounded operation finished. Its deadline must
+// exceed `SUPERVISOR_TIMEOUT` by a real margin, not equal it: the two
+// clocks start at nearly the same moment, so a guard equal to the
+// supervisor's own budget can expire moments before the supervisor
+// produces the event, on a machine slow enough that the supervisor
+// needs most of its budget to finish. Owner shutdown can also run two
+// `cleanup_timeout`-bounded waits back to back (group quiescence, then
+// group removal) before it closes the observed channel, so the guard
+// covers two full budgets, not one. The margin absorbs scheduling
+// slack without weakening the guard against a supervisor that is
+// genuinely hung — a hung supervisor parks forever and never produces
+// the event, so it still trips this deadline, only later.
+const EVENT_MARGIN: Duration = Duration::from_secs(30);
+const EVENT_TIMEOUT: Duration = SUPERVISOR_TIMEOUT
+    .saturating_mul(2)
+    .saturating_add(EVENT_MARGIN);
+
 const CLOSED_GATE_TIMEOUT: Duration = Duration::from_millis(250);
 const TARGET_FIFO_ENV: &str = "PILOTAGE_TARGET_FIFO";
 pub(super) const TARGET_ESCAPE_GROUP_ENV: &str = "PILOTAGE_TARGET_ESCAPE_GROUP";
@@ -353,8 +370,8 @@ fn make_request(
         runtime_root: parts.runtime_root.clone(),
         artifact_root: parts.artifact_root.clone(),
         run_intent_digest: digest_bytes(format!("integration-{}", parts.name).as_bytes()),
-        startup_timeout: EVENT_TIMEOUT,
-        cleanup_timeout: EVENT_TIMEOUT,
+        startup_timeout: SUPERVISOR_TIMEOUT,
+        cleanup_timeout: SUPERVISOR_TIMEOUT,
     }
 }
 


### PR DESCRIPTION
## Problem

`process_supervision::driver_crash_before_release_never_starts_the_target` failed intermittently under machine load and passed alone (observed once each in the PR #583 and PR #584 gate sweeps). Two causes:

- The fixtures set one duration as both the supervisor's own startup/cleanup budget (`startup_timeout`, `cleanup_timeout`) and the test's deadline for observing the FIFO or channel event that budget produces. Two clocks that start together and expire together read scheduling slack as a supervision defect. Owner shutdown also runs two `cleanup_timeout`-bounded waits back to back before it closes the observed FIFO, so an equal guard covers only one of them.
- `read_attestation` blocked on one long `recv_timeout`. A driver that exits before reporting was caught only by the wall-clock ceiling, because a driver that never opens the ready FIFO leaves the reader thread blocked forever and the channel never disconnects on its own.

## Change

- `SUPERVISOR_TIMEOUT` (60 s) is what production receives. `EVENT_TIMEOUT` derives from it: two budgets plus a 30 s margin. A genuinely hung supervisor still trips the deadline, only later.
- `read_attestation` polls the report channel in 50 ms slices and calls `try_wait()` on the driver child each slice, so a driver exit is observed as the event that ends the wait.

Test files only; no production code changed. The agent that authored the change measured 20× loops of the named test and of the full binary under an isolated workspace-test load with the fix in place; its first over-stacked run (two loops plus an unisolated `cargo test --workspace` sharing one target directory) exposed the second cause above.

## Gates

- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass (exit 0)
- `cargo test -p flight-tune-aviate --test process_supervision`: 20 passed, 0 failed (5.94 s)

Fixes #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1if6FUciZKPLuRhhE5f7S